### PR TITLE
Reorder render

### DIFF
--- a/Compute.py
+++ b/Compute.py
@@ -324,7 +324,7 @@ class ThreeDBackend:
 
         self.draw.addNrmMap(nrm, name, **kwargs)
 
-    def render(self):
+    def startRender(self):
 
         self.vc = self.viewCoords()
         if not self.VRMode:
@@ -358,6 +358,7 @@ class ThreeDBackend:
                              shader)
 
 
+    def finishRender(self):
         self.postProcess()
 
         result = self.draw.getFrame()
@@ -509,15 +510,13 @@ class ThreeDBackend:
         while (not self.doQuit):
             self.vv = self.viewVec()
 
-            self.speed[:] = self.svert * self.vv
-            self.speed += self.shorz * -self.vVhorz()
-            self.pos += self.camSpeed * self.speed
+            self.startRender()
 
             self.frameUpdate()
 
             self.vv = self.viewVec()
 
-            r = self.render()
+            r = self.finishRender()
             data = ("render", np.array(r, dtype="object"))
             try:
                 self.P.put_nowait(data)

--- a/Compute.py
+++ b/Compute.py
@@ -506,15 +506,17 @@ class ThreeDBackend:
         self.totTime = 0
 
         self.onStart()
+        self.vv = self.viewVec()
 
         while (not self.doQuit):
-            self.vv = self.viewVec()
-
             self.startRender()
 
-            self.frameUpdate()
+            while not self.evtQ.empty():
+                self.processEvent()
 
             self.vv = self.viewVec()
+
+            self.frameUpdate()
 
             r = self.finishRender()
             data = ("render", np.array(r, dtype="object"))
@@ -523,8 +525,6 @@ class ThreeDBackend:
             except Full:
                 self.full += 1
 
-            while not self.evtQ.empty():
-                self.processEvent()
 
             self.frameNum += 1
             dt = time.perf_counter() - self.startTime

--- a/Multi.py
+++ b/Multi.py
@@ -1410,7 +1410,7 @@ class CombatApp(ThreeDBackend, AI.AIManager, Anim.AnimManager):
             self.draw.blur(self.exposure * 0.707)
 
         self.oldVMat = np.array(self.vMat)
-        self.oldVPos = np.array(self.pos)
+        self.oldVPos = np.array(self.tempPos)
 
         for i in range(len(self.blackHoles)):
             b = self.blackHoles[i]
@@ -1482,6 +1482,7 @@ class CombatApp(ThreeDBackend, AI.AIManager, Anim.AnimManager):
 
     def onStart(self):
         self.gameStarted = False
+        self.tempPos = np.array(self.pos)
 
         if self.stage == 4:
             self.si.put({'Play':(PATH+'../Sound/NoiseOpen.flac', self.volmFX * 0.9, True)})
@@ -1881,6 +1882,7 @@ class CombatApp(ThreeDBackend, AI.AIManager, Anim.AnimManager):
 
         self.si.put({'SetPos':{'pos':self.pos,
                                'vvh':self.vVhorz()}})
+        self.tempPos[:] = self.pos
 
         if self.VRMode: self.frameUpdateVR()
 


### PR DESCRIPTION
Concurrent render and frameupdate

Performance tests (ssao on, 1248x832 * 0.6)
| | before | after
|-|-|-
| Forest 10 player | 20.5 | 26.7 (+30%)
| Strachan 3 player | 22.5 | 27.1 (+20%)
| Atrium 3 player | 24.8 | 28.0 (+13%)

Better GPU utilization

Tradeoff 1 frame of input latency

Slows down with translates, but not slower than previously